### PR TITLE
Mark mirrored-coreos-flannel CVEs as "waiting"

### DIFF
--- a/docs/_data/cves-v2.6.csv
+++ b/docs/_data/cves-v2.6.csv
@@ -520,14 +520,14 @@ rancher/mirrored-coreos-etcd:v3.4.16-rancher1,passwd,debian,CVE-2017-20002,HIGH,
 rancher/mirrored-coreos-etcd:v3.4.16-rancher1,perl-base,debian,CVE-2020-10543,HIGH,https://avd.aquasec.com/nvd/cve-2020-10543,5.24.1-3+deb9u7,,triaged,
 rancher/mirrored-coreos-etcd:v3.4.16-rancher1,perl-base,debian,CVE-2020-10878,HIGH,https://avd.aquasec.com/nvd/cve-2020-10878,5.24.1-3+deb9u7,,triaged,
 rancher/mirrored-coreos-etcd:v3.4.16-rancher1,perl-base,debian,CVE-2020-12723,HIGH,https://avd.aquasec.com/nvd/cve-2020-12723,5.24.1-3+deb9u7,,triaged,
-rancher/mirrored-coreos-flannel:v0.14.0,apk-tools,alpine,CVE-2021-30139,HIGH,https://avd.aquasec.com/nvd/cve-2021-30139,2.10.6-r0,,triaged,
-rancher/mirrored-coreos-flannel:v0.14.0,busybox,alpine,CVE-2021-28831,HIGH,https://avd.aquasec.com/nvd/cve-2021-28831,1.31.1-r20,,triaged,
-rancher/mirrored-coreos-flannel:v0.14.0,libcrypto1.1,alpine,CVE-2021-23840,HIGH,https://avd.aquasec.com/nvd/cve-2021-23840,1.1.1j-r0,,triaged,
-rancher/mirrored-coreos-flannel:v0.14.0,libcrypto1.1,alpine,CVE-2021-3450,HIGH,https://avd.aquasec.com/nvd/cve-2021-3450,1.1.1k-r0,,triaged,
-rancher/mirrored-coreos-flannel:v0.14.0,libcurl,alpine,CVE-2021-22901,HIGH,https://avd.aquasec.com/nvd/cve-2021-22901,7.77.0-r0,,triaged,
-rancher/mirrored-coreos-flannel:v0.14.0,libssl1.1,alpine,CVE-2021-23840,HIGH,https://avd.aquasec.com/nvd/cve-2021-23840,1.1.1j-r0,,triaged,
-rancher/mirrored-coreos-flannel:v0.14.0,libssl1.1,alpine,CVE-2021-3450,HIGH,https://avd.aquasec.com/nvd/cve-2021-3450,1.1.1k-r0,,triaged,
-rancher/mirrored-coreos-flannel:v0.14.0,ssl_client,alpine,CVE-2021-28831,HIGH,https://avd.aquasec.com/nvd/cve-2021-28831,1.31.1-r20,,triaged,
+rancher/mirrored-coreos-flannel:v0.14.0,apk-tools,alpine,CVE-2021-30139,HIGH,https://avd.aquasec.com/nvd/cve-2021-30139,2.10.6-r0,,waiting,Waiting on next release
+rancher/mirrored-coreos-flannel:v0.14.0,busybox,alpine,CVE-2021-28831,HIGH,https://avd.aquasec.com/nvd/cve-2021-28831,1.31.1-r20,,waiting,Waiting on next release
+rancher/mirrored-coreos-flannel:v0.14.0,libcrypto1.1,alpine,CVE-2021-23840,HIGH,https://avd.aquasec.com/nvd/cve-2021-23840,1.1.1j-r0,,waiting,Waiting on next release
+rancher/mirrored-coreos-flannel:v0.14.0,libcrypto1.1,alpine,CVE-2021-3450,HIGH,https://avd.aquasec.com/nvd/cve-2021-3450,1.1.1k-r0,,waiting,Waiting on next release
+rancher/mirrored-coreos-flannel:v0.14.0,libcurl,alpine,CVE-2021-22901,HIGH,https://avd.aquasec.com/nvd/cve-2021-22901,7.77.0-r0,,waiting,Waiting on next release
+rancher/mirrored-coreos-flannel:v0.14.0,libssl1.1,alpine,CVE-2021-23840,HIGH,https://avd.aquasec.com/nvd/cve-2021-23840,1.1.1j-r0,,waiting,Waiting on next release
+rancher/mirrored-coreos-flannel:v0.14.0,libssl1.1,alpine,CVE-2021-3450,HIGH,https://avd.aquasec.com/nvd/cve-2021-3450,1.1.1k-r0,,waiting,Waiting on next release
+rancher/mirrored-coreos-flannel:v0.14.0,ssl_client,alpine,CVE-2021-28831,HIGH,https://avd.aquasec.com/nvd/cve-2021-28831,1.31.1-r20,,waiting,Waiting on next release
 rancher/mirrored-fluent-fluent-bit:1.7.9,libc6,debian,CVE-2021-33574,CRITICAL,https://avd.aquasec.com/nvd/cve-2021-33574,,,triaged,
 rancher/mirrored-fluent-fluent-bit:1.7.9,libc6,debian,CVE-2020-1751,HIGH,https://avd.aquasec.com/nvd/cve-2020-1751,,,triaged,
 rancher/mirrored-fluent-fluent-bit:1.7.9,libc6,debian,CVE-2020-1752,HIGH,https://avd.aquasec.com/nvd/cve-2020-1752,,,triaged,


### PR DESCRIPTION
The reported CVEs all come from the base alpine image version 3.12.3.
The Dockerfile sets the image version as 3.12[1], which means on the
next build the latest 3.12.x image will be used, which includes the
fixes for all reported CVEs.

[1] https://github.com/flannel-io/flannel/blob/0083735ef9a28fbd5c8bc05f207bc17dfa176514/Dockerfile.amd64#L1